### PR TITLE
Fix C# language adapter for Rider using text-based parser

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -97,6 +97,7 @@ intellijPlatform {
                 <li>Java (requires Java plugin)</li>
                 <li>Kotlin (requires Kotlin plugin)</li>
                 <li>Rust (requires Rust plugin)</li>
+                <li>C# (requires Rider)</li>
                 <li>Swift (macOS only, requires Xcode or Swift toolchain)</li>
             </ul>
 
@@ -114,6 +115,12 @@ intellijPlatform {
         }
 
         changeNotes = """
+            <h3>1.5.0</h3>
+            <ul>
+                <li><b>New:</b> C# language support - find symbols, references, and file structure in C# code</li>
+                <li>Requires JetBrains Rider</li>
+            </ul>
+
             <h3>1.4.0</h3>
             <ul>
                 <li><b>New:</b> Rust language support - find symbols, references, and file structure in Rust code</li>
@@ -173,6 +180,12 @@ intellijPlatformTesting {
         // Run with RustRover (for Rust testing)
         register("runRustRover") {
             type = IntelliJPlatformType.RustRover
+            version = "2025.3.1"
+        }
+
+        // Run with Rider (for C# testing)
+        register("runRider") {
+            type = IntelliJPlatformType.Rider
             version = "2025.3.1"
         }
     }

--- a/core/src/main/kotlin/info/jiayun/intellijmcp/csharp/CSharpLanguageAdapter.kt
+++ b/core/src/main/kotlin/info/jiayun/intellijmcp/csharp/CSharpLanguageAdapter.kt
@@ -1,0 +1,362 @@
+package info.jiayun.intellijmcp.csharp
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import info.jiayun.intellijmcp.api.*
+
+/**
+ * C# language adapter using text-based parsing.
+ *
+ * Rider uses ReSharper's .NET engine for C# — the IntelliJ frontend has only a minimal
+ * PSI facade. Generic IntelliJ PSI types (PsiNamedElement, PsiTreeUtil) don't match
+ * Rider's C# PSI elements, so all PSI-based symbol resolution fails.
+ *
+ * This adapter uses [CSharpTextParser] to extract symbols from source text via regex
+ * patterns, similar to how the Swift adapter uses LSP as an alternative to PSI.
+ */
+class CSharpLanguageAdapter : LanguageAdapter {
+
+    override val languageId = "csharp"
+    override val languageDisplayName = "C#"
+    override val supportedExtensions = setOf("cs")
+
+    private val parser = CSharpTextParser()
+
+    // ===== Find Symbol =====
+
+    override fun findSymbol(
+        project: Project,
+        name: String,
+        kind: SymbolKind?
+    ): List<SymbolInfo> {
+        val scope = GlobalSearchScope.projectScope(project)
+        val results = mutableListOf<SymbolInfo>()
+
+        FilenameIndex.getAllFilesByExt(project, "cs", scope).forEach { virtualFile ->
+            val text = try {
+                String(virtualFile.contentsToByteArray(), virtualFile.charset)
+            } catch (_: Exception) {
+                return@forEach
+            }
+
+            val parsed = parser.parse(text)
+            val filePath = virtualFile.path
+
+            val matching = parser.findSymbolsByName(parsed, name)
+            for (symbol in matching) {
+                val symbolKind = mapKind(symbol.kind)
+                if (kind == null || kind == symbolKind) {
+                    results.add(toSymbolInfo(symbol, filePath, parsed.namespaceName))
+                }
+            }
+        }
+
+        return results
+    }
+
+    // ===== Find References =====
+
+    override fun findReferences(
+        project: Project,
+        filePath: String,
+        offset: Int
+    ): List<LocationInfo> {
+        // Get symbol name at position
+        val text = readFileText(project, filePath)
+            ?: throw IllegalArgumentException("File not found: $filePath")
+
+        val symbolName = extractWordAtOffset(text, offset)
+            ?: throw IllegalArgumentException("No symbol at offset")
+
+        // Search all .cs files for whole-word occurrences
+        val scope = GlobalSearchScope.projectScope(project)
+        val results = mutableListOf<LocationInfo>()
+        val wordRegex = Regex("""\b${Regex.escape(symbolName)}\b""")
+
+        FilenameIndex.getAllFilesByExt(project, "cs", scope).forEach { virtualFile ->
+            val fileText = try {
+                String(virtualFile.contentsToByteArray(), virtualFile.charset)
+            } catch (_: Exception) {
+                return@forEach
+            }
+
+            val lines = fileText.lines()
+            for ((lineIdx, line) in lines.withIndex()) {
+                for (match in wordRegex.findAll(line)) {
+                    // Skip matches inside comments
+                    val beforeMatch = line.substring(0, match.range.first)
+                    if (beforeMatch.contains("//") || beforeMatch.contains("/*")) continue
+
+                    // Skip matches inside string literals (basic heuristic)
+                    val quoteCount = beforeMatch.count { it == '"' }
+                    if (quoteCount % 2 != 0) continue
+
+                    results.add(LocationInfo(
+                        filePath = virtualFile.path,
+                        line = lineIdx + 1,
+                        column = match.range.first + 1,
+                        endLine = lineIdx + 1,
+                        endColumn = match.range.last + 2,
+                        preview = line.trim()
+                    ))
+                }
+            }
+        }
+
+        return results
+    }
+
+    // ===== Get Symbol Info =====
+
+    override fun getSymbolInfo(
+        project: Project,
+        filePath: String,
+        offset: Int
+    ): SymbolInfo? {
+        val text = readFileText(project, filePath) ?: return null
+        val (line, column) = offsetToLineColumn(text, offset) ?: return null
+
+        val parsed = parser.parse(text)
+        val symbol = parser.findSymbolAt(parsed, line, column) ?: return null
+
+        return toSymbolInfo(symbol, filePath, parsed.namespaceName)
+    }
+
+    // ===== Get File Symbols =====
+
+    override fun getFileSymbols(
+        project: Project,
+        filePath: String
+    ): FileSymbols {
+        val text = readFileText(project, filePath)
+            ?: throw IllegalArgumentException("File not found: $filePath")
+
+        val parsed = parser.parse(text)
+
+        val imports = parsed.usings.map { using ->
+            ImportInfo(
+                module = using.module,
+                alias = using.alias,
+                names = null,
+                location = LocationInfo(
+                    filePath = filePath,
+                    line = using.line,
+                    column = using.column
+                )
+            )
+        }
+
+        val symbols = parsed.symbols.map { toSymbolNode(it, filePath, parsed.namespaceName) }
+
+        return FileSymbols(
+            filePath = filePath,
+            language = languageId,
+            packageName = parsed.namespaceName,
+            imports = imports,
+            symbols = symbols
+        )
+    }
+
+    // ===== Get Type Hierarchy =====
+
+    override fun getTypeHierarchy(
+        project: Project,
+        typeName: String
+    ): TypeHierarchy? {
+        val scope = GlobalSearchScope.projectScope(project)
+
+        FilenameIndex.getAllFilesByExt(project, "cs", scope).forEach { virtualFile ->
+            val text = try {
+                String(virtualFile.contentsToByteArray(), virtualFile.charset)
+            } catch (_: Exception) {
+                return@forEach
+            }
+
+            val parsed = parser.parse(text)
+            val matching = parser.findSymbolsByName(parsed, typeName)
+            val typeSymbol = matching.firstOrNull { isTypeKind(it.kind) } ?: return@forEach
+
+            val superTypes = typeSymbol.baseTypes.map { baseType ->
+                TypeRef(name = baseType, qualifiedName = null, location = null)
+            }
+
+            return TypeHierarchy(
+                typeName = typeSymbol.name,
+                qualifiedName = parsed.namespaceName?.let { "$it.${typeSymbol.name}" },
+                kind = mapKind(typeSymbol.kind),
+                superTypes = superTypes,
+                subTypes = emptyList()
+            )
+        }
+
+        return null
+    }
+
+    // ===== Get Offset =====
+
+    override fun getOffset(
+        project: Project,
+        filePath: String,
+        line: Int,
+        column: Int
+    ): Int? {
+        val psiFile = getCsFile(project, filePath) ?: return null
+        val document = PsiDocumentManager.getInstance(project).getDocument(psiFile) ?: return null
+
+        // Convert 1-based to 0-based
+        val lineIndex = line - 1
+        val columnIndex = column - 1
+
+        if (lineIndex < 0 || lineIndex >= document.lineCount) return null
+
+        val lineStartOffset = document.getLineStartOffset(lineIndex)
+        val lineEndOffset = document.getLineEndOffset(lineIndex)
+        val offset = lineStartOffset + columnIndex
+
+        return if (offset <= lineEndOffset) offset else null
+    }
+
+    // ===== Helper Methods =====
+
+    private fun getCsFile(project: Project, filePath: String): PsiFile? {
+        val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
+        return PsiManager.getInstance(project).findFile(virtualFile)
+    }
+
+    private fun readFileText(project: Project, filePath: String): String? {
+        val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
+        return try {
+            String(virtualFile.contentsToByteArray(), virtualFile.charset)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Convert a 0-based offset to 1-based line and column.
+     */
+    private fun offsetToLineColumn(text: String, offset: Int): Pair<Int, Int>? {
+        if (offset < 0 || offset >= text.length) return null
+
+        var line = 1
+        var col = 1
+        for (i in 0 until offset) {
+            if (text[i] == '\n') {
+                line++
+                col = 1
+            } else {
+                col++
+            }
+        }
+        return Pair(line, col)
+    }
+
+    /**
+     * Extract the word (identifier) at a given 0-based offset.
+     */
+    private fun extractWordAtOffset(text: String, offset: Int): String? {
+        if (offset < 0 || offset >= text.length) return null
+        if (!text[offset].isLetterOrDigit() && text[offset] != '_') return null
+
+        var start = offset
+        var end = offset
+        while (start > 0 && (text[start - 1].isLetterOrDigit() || text[start - 1] == '_')) start--
+        while (end < text.length && (text[end].isLetterOrDigit() || text[end] == '_')) end++
+
+        return if (start < end) text.substring(start, end) else null
+    }
+
+    /**
+     * Map parser symbol kind to API SymbolKind.
+     */
+    private fun mapKind(kind: CSharpTextParser.ParsedSymbolKind): SymbolKind {
+        return when (kind) {
+            CSharpTextParser.ParsedSymbolKind.NAMESPACE -> SymbolKind.MODULE
+            CSharpTextParser.ParsedSymbolKind.CLASS -> SymbolKind.CLASS
+            CSharpTextParser.ParsedSymbolKind.STRUCT -> SymbolKind.CLASS
+            CSharpTextParser.ParsedSymbolKind.ENUM -> SymbolKind.ENUM
+            CSharpTextParser.ParsedSymbolKind.INTERFACE -> SymbolKind.INTERFACE
+            CSharpTextParser.ParsedSymbolKind.RECORD -> SymbolKind.CLASS
+            CSharpTextParser.ParsedSymbolKind.METHOD -> SymbolKind.METHOD
+            CSharpTextParser.ParsedSymbolKind.CONSTRUCTOR -> SymbolKind.METHOD
+            CSharpTextParser.ParsedSymbolKind.PROPERTY -> SymbolKind.PROPERTY
+            CSharpTextParser.ParsedSymbolKind.FIELD -> SymbolKind.FIELD
+            CSharpTextParser.ParsedSymbolKind.EVENT -> SymbolKind.FIELD
+            CSharpTextParser.ParsedSymbolKind.ENUM_MEMBER -> SymbolKind.CONSTANT
+        }
+    }
+
+    private fun isTypeKind(kind: CSharpTextParser.ParsedSymbolKind): Boolean {
+        return kind in setOf(
+            CSharpTextParser.ParsedSymbolKind.CLASS,
+            CSharpTextParser.ParsedSymbolKind.STRUCT,
+            CSharpTextParser.ParsedSymbolKind.ENUM,
+            CSharpTextParser.ParsedSymbolKind.INTERFACE,
+            CSharpTextParser.ParsedSymbolKind.RECORD
+        )
+    }
+
+    /**
+     * Convert a parsed symbol to SymbolInfo.
+     */
+    private fun toSymbolInfo(
+        symbol: CSharpTextParser.ParsedSymbol,
+        filePath: String,
+        namespaceName: String?
+    ): SymbolInfo {
+        val kind = mapKind(symbol.kind)
+        val qualifiedName = namespaceName?.let { "$it.${symbol.name}" }
+
+        return SymbolInfo(
+            name = symbol.name,
+            kind = kind,
+            language = languageId,
+            qualifiedName = qualifiedName,
+            signature = symbol.signature,
+            documentation = symbol.documentation,
+            location = LocationInfo(
+                filePath = filePath,
+                line = symbol.line,
+                column = symbol.column,
+                endLine = symbol.endLine,
+                endColumn = symbol.endColumn,
+                preview = symbol.signature?.take(100)
+            ),
+            nameLocation = LocationInfo(
+                filePath = filePath,
+                line = symbol.line,
+                column = symbol.nameColumn
+            ),
+            returnType = symbol.returnType,
+            parameters = symbol.parameters?.map { p ->
+                ParameterInfo(
+                    name = p.name,
+                    type = p.type,
+                    defaultValue = p.defaultValue,
+                    isOptional = p.isOptional
+                )
+            },
+            modifiers = symbol.modifiers.takeIf { it.isNotEmpty() },
+            annotations = symbol.attributes.takeIf { it.isNotEmpty() },
+            superTypes = symbol.baseTypes.takeIf { it.isNotEmpty() }
+        )
+    }
+
+    /**
+     * Convert a parsed symbol to a SymbolNode (with children).
+     */
+    private fun toSymbolNode(
+        symbol: CSharpTextParser.ParsedSymbol,
+        filePath: String,
+        namespaceName: String?
+    ): SymbolNode {
+        val info = toSymbolInfo(symbol, filePath, namespaceName)
+        val children = symbol.children.map { toSymbolNode(it, filePath, namespaceName) }
+        return SymbolNode(symbol = info, children = children)
+    }
+}

--- a/core/src/main/kotlin/info/jiayun/intellijmcp/csharp/CSharpTextParser.kt
+++ b/core/src/main/kotlin/info/jiayun/intellijmcp/csharp/CSharpTextParser.kt
@@ -1,0 +1,834 @@
+package info.jiayun.intellijmcp.csharp
+
+/**
+ * Text-based C# parser that extracts symbols from source files using regex patterns.
+ *
+ * This parser is used instead of PSI because Rider's C# PSI elements are backed by
+ * ReSharper's .NET engine and are not accessible from a pure IntelliJ frontend plugin.
+ * The text-based approach has no external dependencies and works immediately.
+ */
+class CSharpTextParser {
+
+    data class ParsedFile(
+        val usings: List<UsingDirective>,
+        val namespaceName: String?,
+        val symbols: List<ParsedSymbol>
+    )
+
+    data class UsingDirective(
+        val module: String,
+        val alias: String?,
+        val line: Int,       // 1-based
+        val column: Int      // 1-based
+    )
+
+    data class ParsedSymbol(
+        val name: String,
+        val kind: ParsedSymbolKind,
+        val modifiers: List<String>,
+        val attributes: List<String>,
+        val signature: String?,
+        val returnType: String?,
+        val parameters: List<ParsedParameter>?,
+        val baseTypes: List<String>,
+        val documentation: String?,
+        val line: Int,           // 1-based, line of the declaration keyword/name
+        val column: Int,         // 1-based
+        val nameColumn: Int,     // 1-based, column where the name starts
+        val endLine: Int,        // 1-based, end of the symbol's block
+        val endColumn: Int,      // 1-based
+        val children: List<ParsedSymbol>
+    )
+
+    data class ParsedParameter(
+        val name: String,
+        val type: String,
+        val defaultValue: String?,
+        val isOptional: Boolean
+    )
+
+    enum class ParsedSymbolKind {
+        NAMESPACE, CLASS, STRUCT, ENUM, INTERFACE, RECORD,
+        METHOD, CONSTRUCTOR, PROPERTY, FIELD, EVENT, ENUM_MEMBER
+    }
+
+    companion object {
+        private val MODIFIER_KEYWORDS = setOf(
+            "public", "private", "protected", "internal",
+            "static", "abstract", "virtual", "override",
+            "async", "readonly", "sealed", "new", "partial",
+            "extern", "volatile", "unsafe", "const"
+        )
+
+        private val TYPE_KEYWORDS = setOf("class", "struct", "enum", "interface", "record")
+
+        // Regex for using directives
+        private val USING_REGEX = Regex(
+            """^\s*using\s+(?:static\s+)?(?:(\w+)\s*=\s*)?([^;]+)\s*;"""
+        )
+
+        // Regex for namespace (both block and file-scoped)
+        private val NAMESPACE_REGEX = Regex(
+            """^\s*namespace\s+([\w.]+)\s*[;{]"""
+        )
+
+        // Regex for type declarations
+        private val TYPE_DECL_REGEX = Regex(
+            """^(\s*(?:(?:${MODIFIER_KEYWORDS.joinToString("|")})\s+)*)""" +
+            """(class|struct|enum|interface|record)\s+""" +
+            """(\w+)""" +
+            """(?:<[^>]+>)?""" +   // optional generic params
+            """(?:\s*:\s*([^{;]+))?""" +  // optional base types
+            """(?:\s*where\b[^{;]*)?"""   // optional generic constraints
+        )
+
+        // Regex for method/constructor declarations
+        private val METHOD_REGEX = Regex(
+            """^(\s*(?:(?:${MODIFIER_KEYWORDS.joinToString("|")})\s+)*)""" +
+            """(?:(\S+(?:<[^>]+>)?)\s+)?""" +  // return type (optional for constructors)
+            """(\w+)\s*""" +
+            """(?:<[^>]+>)?\s*""" +  // optional generic params
+            """\(([^)]*)\)\s*""" +   // parameters
+            """(?::\s*(?:base|this)\s*\([^)]*\)\s*)?""" +  // optional base/this call
+            """(?:\{|=>|;)"""        // body start
+        )
+
+        // Regex for property declarations (block body with { get; set; })
+        private val PROPERTY_REGEX = Regex(
+            """^(\s*(?:(?:${MODIFIER_KEYWORDS.joinToString("|")})\s+)*)""" +
+            """(\S+(?:<[^>]+>)?(?:\?|\[\])?)\s+""" +  // type
+            """(\w+)\s*""" +
+            """\{"""                   // opening brace (property body)
+        )
+
+        // Regex for expression-bodied property: Type Name => expr;
+        private val EXPR_PROPERTY_REGEX = Regex(
+            """^(\s*(?:(?:${MODIFIER_KEYWORDS.joinToString("|")})\s+)*)""" +
+            """(\S+(?:<[^>]+>)?(?:\?|\[\])?)\s+""" +  // type
+            """(\w+)\s*""" +
+            """=>\s*[^;]+;"""          // expression body ending with semicolon
+        )
+
+        // Regex for field/event declarations
+        private val FIELD_REGEX = Regex(
+            """^(\s*(?:(?:${MODIFIER_KEYWORDS.joinToString("|")})\s+)*)""" +
+            """(event\s+)?""" +        // optional event keyword
+            """(\S+(?:<[^>]+>)?(?:\?|\[\])?)\s+""" +  // type
+            """(\w+)\s*""" +
+            """(?:=\s*[^;]+)?;"""      // optional initializer, ending with semicolon
+        )
+
+        // Regex for XML doc comments
+        private val DOC_COMMENT_REGEX = Regex("""^\s*///\s?(.*)""")
+
+        // Regex for attribute
+        private val ATTRIBUTE_REGEX = Regex("""^\s*\[([^\]]+)\]""")
+    }
+
+    fun parse(text: String): ParsedFile {
+        val lines = text.lines()
+        val usings = mutableListOf<UsingDirective>()
+        var namespaceName: String? = null
+        val topLevelSymbols = mutableListOf<ParsedSymbol>()
+
+        var i = 0
+        while (i < lines.size) {
+            val line = lines[i]
+            val trimmed = line.trim()
+
+            // Skip blank lines and comments (non-doc)
+            if (trimmed.isEmpty() || trimmed.startsWith("//") && !trimmed.startsWith("///")) {
+                i++
+                continue
+            }
+
+            // Using directives
+            val usingMatch = USING_REGEX.find(line)
+            if (usingMatch != null) {
+                val alias = usingMatch.groupValues[1].takeIf { it.isNotEmpty() }
+                val module = usingMatch.groupValues[2].trim()
+                usings.add(UsingDirective(
+                    module = module,
+                    alias = alias,
+                    line = i + 1,
+                    column = line.indexOf("using") + 1
+                ))
+                i++
+                continue
+            }
+
+            // Namespace
+            val nsMatch = NAMESPACE_REGEX.find(line)
+            if (nsMatch != null) {
+                namespaceName = nsMatch.groupValues[1]
+                // If file-scoped namespace (ends with ;), just continue
+                if (trimmed.endsWith(";")) {
+                    i++
+                    continue
+                }
+                // Block namespace - parse its contents
+                val blockStart = i
+                val blockEnd = findMatchingBrace(lines, i)
+                val innerSymbols = parseBlock(lines, blockStart + 1, blockEnd - 1)
+                topLevelSymbols.addAll(innerSymbols)
+                i = blockEnd + 1
+                continue
+            }
+
+            // Try to parse a type or member declaration
+            val result = tryParseDeclaration(lines, i)
+            if (result != null) {
+                topLevelSymbols.add(result.first)
+                i = result.second + 1
+                continue
+            }
+
+            i++
+        }
+
+        return ParsedFile(
+            usings = usings,
+            namespaceName = namespaceName,
+            symbols = topLevelSymbols
+        )
+    }
+
+    /**
+     * Parse symbols within a block (between braces).
+     */
+    private fun parseBlock(lines: List<String>, startLine: Int, endLine: Int): List<ParsedSymbol> {
+        val symbols = mutableListOf<ParsedSymbol>()
+        var i = startLine
+
+        while (i <= endLine && i < lines.size) {
+            val trimmed = lines[i].trim()
+
+            if (trimmed.isEmpty() || (trimmed.startsWith("//") && !trimmed.startsWith("///"))) {
+                i++
+                continue
+            }
+
+            val result = tryParseDeclaration(lines, i)
+            if (result != null) {
+                symbols.add(result.first)
+                i = result.second + 1
+                continue
+            }
+
+            i++
+        }
+
+        return symbols
+    }
+
+    /**
+     * Try to parse a declaration starting at the given line.
+     * Returns (ParsedSymbol, lastLineIndex) or null if not a recognized declaration.
+     */
+    private fun tryParseDeclaration(lines: List<String>, startLine: Int): Pair<ParsedSymbol, Int>? {
+        // Collect doc comments and attributes above the declaration
+        val docLines = mutableListOf<String>()
+        val attributes = mutableListOf<String>()
+
+        var declLine = startLine
+
+        // Scan forward: collect doc comments and attributes before the declaration
+        while (declLine < lines.size) {
+            val trimmed = lines[declLine].trim()
+            val docMatch = DOC_COMMENT_REGEX.find(trimmed)
+
+            when {
+                docMatch != null -> {
+                    docLines.add(docMatch.groupValues[1])
+                    declLine++
+                }
+                trimmed.isEmpty() -> {
+                    declLine++
+                }
+                else -> {
+                    // Collect any attributes, including inline ones (e.g., "[SerializeField] private int x;")
+                    // Attributes may appear at the start of the line before the declaration
+                    var remaining = trimmed
+                    while (true) {
+                        val attrMatch = ATTRIBUTE_REGEX.find(remaining) ?: break
+                        attributes.add("[${attrMatch.groupValues[1]}]")
+                        remaining = remaining.substring(attrMatch.range.last + 1).trim()
+                        if (remaining.isEmpty()) {
+                            // Attribute was the entire line, advance to next line
+                            declLine++
+                            break
+                        }
+                    }
+                    break
+                }
+            }
+        }
+
+        if (declLine >= lines.size) return null
+
+        val line = lines[declLine]
+        val trimmed = line.trim()
+
+        // Skip preprocessor directives
+        if (trimmed.startsWith("#")) return Pair(createSkipSymbol(declLine), declLine)
+
+        // Build a multi-line declaration string for matching (join continuation lines)
+        // Strip any leading inline attributes so regex patterns can match the declaration itself
+        val declText = stripLeadingAttributes(buildDeclText(lines, declLine))
+        val documentation = docLines.joinToString("\n").takeIf { it.isNotEmpty() }
+
+        // Try type declaration
+        val typeResult = tryParseType(lines, declLine, declText, attributes, documentation)
+        if (typeResult != null) return typeResult
+
+        // Try method/constructor
+        val methodResult = tryParseMethod(lines, declLine, declText, attributes, documentation)
+        if (methodResult != null) return methodResult
+
+        // Try property — block body (must come before field since both start with type + name)
+        val propResult = tryParseProperty(lines, declLine, declText, attributes, documentation)
+        if (propResult != null) return propResult
+
+        // Try expression-bodied property (Type Name => expr;)
+        val exprPropResult = tryParseExprProperty(lines, declLine, declText, attributes, documentation)
+        if (exprPropResult != null) return exprPropResult
+
+        // Try field/event
+        val fieldResult = tryParseField(lines, declLine, declText, attributes, documentation)
+        if (fieldResult != null) return fieldResult
+
+        // Try enum member (simple identifier, possibly with value, ending with comma)
+        val enumMemberResult = tryParseEnumMember(lines, declLine, trimmed, attributes, documentation)
+        if (enumMemberResult != null) return enumMemberResult
+
+        // If we collected doc/attributes but couldn't parse, still advance past them
+        if (declLine > startLine) {
+            return null  // Let caller advance by 1
+        }
+
+        return null
+    }
+
+    private fun createSkipSymbol(line: Int): ParsedSymbol {
+        return ParsedSymbol(
+            name = "",
+            kind = ParsedSymbolKind.FIELD,
+            modifiers = emptyList(),
+            attributes = emptyList(),
+            signature = null,
+            returnType = null,
+            parameters = null,
+            baseTypes = emptyList(),
+            documentation = null,
+            line = line + 1,
+            column = 1,
+            nameColumn = 1,
+            endLine = line + 1,
+            endColumn = 1,
+            children = emptyList()
+        )
+    }
+
+    private fun tryParseType(
+        lines: List<String>,
+        declLine: Int,
+        declText: String,
+        attributes: List<String>,
+        documentation: String?
+    ): Pair<ParsedSymbol, Int>? {
+        val match = TYPE_DECL_REGEX.find(declText) ?: return null
+
+        val modifierStr = match.groupValues[1].trim()
+        val typeKeyword = match.groupValues[2]
+        val name = match.groupValues[3]
+        val baseTypesStr = match.groupValues[4].trim()
+
+        val modifiers = extractModifiers(modifierStr)
+        val baseTypes = if (baseTypesStr.isNotEmpty()) {
+            baseTypesStr.split(",").map { it.trim().split("<").first().trim() }.filter { it.isNotEmpty() }
+        } else emptyList()
+
+        val kind = when (typeKeyword) {
+            "class" -> ParsedSymbolKind.CLASS
+            "struct" -> ParsedSymbolKind.STRUCT
+            "enum" -> ParsedSymbolKind.ENUM
+            "interface" -> ParsedSymbolKind.INTERFACE
+            "record" -> ParsedSymbolKind.RECORD
+            else -> ParsedSymbolKind.CLASS
+        }
+
+        val line = lines[declLine]
+        val nameCol = line.indexOf(name, line.indexOf(typeKeyword)) + 1
+
+        // Find the block end
+        val blockEnd = findMatchingBrace(lines, declLine)
+        val children = if (blockEnd > declLine) {
+            parseBlock(lines, declLine + 1, blockEnd - 1)
+        } else emptyList()
+
+        // Build signature (first line of declaration)
+        val sigEnd = declText.indexOf('{').let { if (it >= 0) it else declText.length }
+        val signature = declText.substring(0, sigEnd).trim()
+            .replace(Regex("""\s+"""), " ")
+
+        val symbol = ParsedSymbol(
+            name = name,
+            kind = kind,
+            modifiers = modifiers,
+            attributes = attributes,
+            signature = signature,
+            returnType = null,
+            parameters = null,
+            baseTypes = baseTypes,
+            documentation = documentation,
+            line = declLine + 1,
+            column = (line.length - line.trimStart().length) + 1,
+            nameColumn = nameCol,
+            endLine = blockEnd + 1,
+            endColumn = if (blockEnd < lines.size) lines[blockEnd].length + 1 else 1,
+            children = children.filter { it.name.isNotEmpty() }
+        )
+
+        return Pair(symbol, blockEnd)
+    }
+
+    private fun tryParseMethod(
+        lines: List<String>,
+        declLine: Int,
+        declText: String,
+        attributes: List<String>,
+        documentation: String?
+    ): Pair<ParsedSymbol, Int>? {
+        val match = METHOD_REGEX.find(declText) ?: return null
+
+        val modifierStr = match.groupValues[1].trim()
+        val returnType = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+        val name = match.groupValues[3]
+        val paramStr = match.groupValues[4].trim()
+
+        // Skip if name is a C# keyword (likely a control flow statement)
+        if (name in setOf("if", "else", "for", "foreach", "while", "do", "switch", "try", "catch", "finally",
+                "using", "lock", "return", "throw", "yield", "await", "new", "typeof", "sizeof", "nameof")) {
+            return null
+        }
+
+        val modifiers = extractModifiers(modifierStr)
+        val parameters = parseParameters(paramStr)
+        val isConstructor = returnType == null || name == returnType
+
+        val kind = if (isConstructor) ParsedSymbolKind.CONSTRUCTOR else ParsedSymbolKind.METHOD
+
+        val line = lines[declLine]
+        val nameCol = line.indexOf(name) + 1
+
+        // Find end: either matching brace or semicolon (for abstract/extern methods)
+        val endLine = if (declText.trimEnd().endsWith(";")) {
+            declLine
+        } else {
+            findMatchingBrace(lines, declLine)
+        }
+
+        val sigEnd = declText.indexOf('{').let {
+            if (it >= 0) it else declText.indexOf("=>").let { a ->
+                if (a >= 0) a else declText.indexOf(';').let { b ->
+                    if (b >= 0) b else declText.length
+                }
+            }
+        }
+        val signature = declText.substring(0, sigEnd).trim().replace(Regex("""\s+"""), " ")
+
+        val symbol = ParsedSymbol(
+            name = name,
+            kind = kind,
+            modifiers = modifiers,
+            attributes = attributes,
+            signature = signature,
+            returnType = if (isConstructor) null else returnType,
+            parameters = parameters,
+            baseTypes = emptyList(),
+            documentation = documentation,
+            line = declLine + 1,
+            column = (line.length - line.trimStart().length) + 1,
+            nameColumn = nameCol,
+            endLine = endLine + 1,
+            endColumn = if (endLine < lines.size) lines[endLine].length + 1 else 1,
+            children = emptyList()
+        )
+
+        return Pair(symbol, endLine)
+    }
+
+    private fun tryParseProperty(
+        lines: List<String>,
+        declLine: Int,
+        declText: String,
+        attributes: List<String>,
+        documentation: String?
+    ): Pair<ParsedSymbol, Int>? {
+        val match = PROPERTY_REGEX.find(declText) ?: return null
+
+        // Verify it's actually a property (has get/set inside braces)
+        val braceStart = declText.indexOf('{')
+        if (braceStart < 0) return null
+
+        // Quick check: look for get/set within a reasonable range
+        val afterBrace = declText.substring(braceStart)
+        if (!afterBrace.contains("get") && !afterBrace.contains("set") &&
+            !afterBrace.contains("init") && !afterBrace.contains("=>")) {
+            return null
+        }
+
+        val modifierStr = match.groupValues[1].trim()
+        val type = match.groupValues[2].trim()
+        val name = match.groupValues[3]
+
+        // Skip if type looks like a keyword
+        if (type in TYPE_KEYWORDS || type in setOf("return", "if", "else", "new")) return null
+
+        val modifiers = extractModifiers(modifierStr)
+
+        val line = lines[declLine]
+        val nameCol = line.indexOf(name) + 1
+
+        val endLine = findMatchingBrace(lines, declLine)
+
+        val sigEnd = declText.indexOf('{')
+        val signature = declText.substring(0, sigEnd).trim().replace(Regex("""\s+"""), " ")
+
+        val symbol = ParsedSymbol(
+            name = name,
+            kind = ParsedSymbolKind.PROPERTY,
+            modifiers = modifiers,
+            attributes = attributes,
+            signature = signature,
+            returnType = type,
+            parameters = null,
+            baseTypes = emptyList(),
+            documentation = documentation,
+            line = declLine + 1,
+            column = (line.length - line.trimStart().length) + 1,
+            nameColumn = nameCol,
+            endLine = endLine + 1,
+            endColumn = if (endLine < lines.size) lines[endLine].length + 1 else 1,
+            children = emptyList()
+        )
+
+        return Pair(symbol, endLine)
+    }
+
+    private fun tryParseExprProperty(
+        lines: List<String>,
+        declLine: Int,
+        declText: String,
+        attributes: List<String>,
+        documentation: String?
+    ): Pair<ParsedSymbol, Int>? {
+        val match = EXPR_PROPERTY_REGEX.find(declText) ?: return null
+
+        val modifierStr = match.groupValues[1].trim()
+        val type = match.groupValues[2].trim()
+        val name = match.groupValues[3]
+
+        if (type in TYPE_KEYWORDS || type in setOf("return", "if", "else", "new")) return null
+
+        val modifiers = extractModifiers(modifierStr)
+
+        val line = lines[declLine]
+        val nameCol = line.indexOf(name) + 1
+        val endLine = findSemicolon(lines, declLine)
+
+        val signature = declText.substringBefore(';').trim().replace(Regex("""\s+"""), " ") + ";"
+
+        val symbol = ParsedSymbol(
+            name = name,
+            kind = ParsedSymbolKind.PROPERTY,
+            modifiers = modifiers,
+            attributes = attributes,
+            signature = signature,
+            returnType = type,
+            parameters = null,
+            baseTypes = emptyList(),
+            documentation = documentation,
+            line = declLine + 1,
+            column = (line.length - line.trimStart().length) + 1,
+            nameColumn = nameCol,
+            endLine = endLine + 1,
+            endColumn = if (endLine < lines.size) lines[endLine].length + 1 else 1,
+            children = emptyList()
+        )
+
+        return Pair(symbol, endLine)
+    }
+
+    private fun tryParseField(
+        lines: List<String>,
+        declLine: Int,
+        declText: String,
+        attributes: List<String>,
+        documentation: String?
+    ): Pair<ParsedSymbol, Int>? {
+        val match = FIELD_REGEX.find(declText) ?: return null
+
+        val modifierStr = match.groupValues[1].trim()
+        val eventKeyword = match.groupValues[2].trim()
+        val type = match.groupValues[3].trim()
+        val name = match.groupValues[4]
+
+        // Skip if type looks like a keyword
+        if (type in TYPE_KEYWORDS || type in setOf("return", "if", "else", "new", "using", "namespace")) return null
+
+        val modifiers = extractModifiers(modifierStr)
+        val isEvent = eventKeyword.isNotEmpty()
+
+        val kind = when {
+            isEvent -> ParsedSymbolKind.EVENT
+            else -> ParsedSymbolKind.FIELD
+        }
+
+        val line = lines[declLine]
+        val nameCol = line.indexOf(name) + 1
+
+        // Fields end at the semicolon on this line (or nearby)
+        val endLine = findSemicolon(lines, declLine)
+
+        val signature = declText.substringBefore(';').trim().replace(Regex("""\s+"""), " ") + ";"
+
+        val symbol = ParsedSymbol(
+            name = name,
+            kind = kind,
+            modifiers = modifiers,
+            attributes = attributes,
+            signature = signature,
+            returnType = type,
+            parameters = null,
+            baseTypes = emptyList(),
+            documentation = documentation,
+            line = declLine + 1,
+            column = (line.length - line.trimStart().length) + 1,
+            nameColumn = nameCol,
+            endLine = endLine + 1,
+            endColumn = if (endLine < lines.size) lines[endLine].length + 1 else 1,
+            children = emptyList()
+        )
+
+        return Pair(symbol, endLine)
+    }
+
+    private fun tryParseEnumMember(
+        lines: List<String>,
+        declLine: Int,
+        trimmed: String,
+        attributes: List<String>,
+        documentation: String?
+    ): Pair<ParsedSymbol, Int>? {
+        // Enum members: Name, or Name = value,
+        val match = Regex("""^(\w+)\s*(?:=\s*[^,}]+)?\s*[,}]?$""").find(trimmed) ?: return null
+        val name = match.groupValues[1]
+
+        // Skip if it looks like a keyword
+        if (name in MODIFIER_KEYWORDS || name in TYPE_KEYWORDS || name in setOf(
+                "return", "if", "else", "new", "get", "set", "value")) return null
+
+        val line = lines[declLine]
+        val nameCol = line.indexOf(name) + 1
+
+        val symbol = ParsedSymbol(
+            name = name,
+            kind = ParsedSymbolKind.ENUM_MEMBER,
+            modifiers = emptyList(),
+            attributes = attributes,
+            signature = trimmed.trimEnd(',').trim(),
+            returnType = null,
+            parameters = null,
+            baseTypes = emptyList(),
+            documentation = documentation,
+            line = declLine + 1,
+            column = (line.length - line.trimStart().length) + 1,
+            nameColumn = nameCol,
+            endLine = declLine + 1,
+            endColumn = line.length + 1,
+            children = emptyList()
+        )
+
+        return Pair(symbol, declLine)
+    }
+
+    private fun extractModifiers(text: String): List<String> {
+        return text.split(Regex("""\s+""")).filter { it in MODIFIER_KEYWORDS }
+    }
+
+    private fun parseParameters(paramStr: String): List<ParsedParameter> {
+        if (paramStr.isBlank()) return emptyList()
+
+        return paramStr.split(",").mapNotNull { param ->
+            val p = param.trim()
+            if (p.isEmpty()) return@mapNotNull null
+
+            // Handle params keyword, ref, out, in
+            val cleaned = p.replace(Regex("""^(params|ref|out|in|this)\s+"""), "")
+
+            val parts = cleaned.split(Regex("""\s+"""))
+            if (parts.size >= 2) {
+                val defaultMatch = Regex("""=\s*(.+)$""").find(cleaned)
+                val namePart = parts.last().split("=").first().trim()
+                val typePart = parts.dropLast(1).joinToString(" ").split("=").first().trim()
+
+                ParsedParameter(
+                    name = namePart,
+                    type = typePart,
+                    defaultValue = defaultMatch?.groupValues?.get(1)?.trim(),
+                    isOptional = defaultMatch != null
+                )
+            } else null
+        }
+    }
+
+    /**
+     * Strip leading attribute annotations from a declaration string.
+     * E.g., "[SerializeField] private int x;" -> "private int x;"
+     */
+    private fun stripLeadingAttributes(text: String): String {
+        var result = text.trimStart()
+        while (result.startsWith("[")) {
+            val closeBracket = result.indexOf(']')
+            if (closeBracket < 0) break
+            result = result.substring(closeBracket + 1).trimStart()
+        }
+        return result
+    }
+
+    /**
+     * Build a multi-line declaration string by joining lines until we hit a brace, semicolon, or arrow.
+     */
+    private fun buildDeclText(lines: List<String>, startLine: Int): String {
+        val sb = StringBuilder()
+        var i = startLine
+        var braceDepth = 0
+        while (i < lines.size && i < startLine + 10) {  // Look at most 10 lines
+            val line = lines[i]
+            sb.append(if (i == startLine) line else " $line")
+
+            for (ch in line) {
+                when (ch) {
+                    '{' -> braceDepth++
+                    '}' -> braceDepth--
+                }
+            }
+
+            val current = sb.toString().trim()
+            if (current.contains('{') || current.endsWith(";") || current.contains("=>")) {
+                break
+            }
+            i++
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Find the line index of the matching closing brace for an opening brace
+     * starting at or after the given line.
+     */
+    private fun findMatchingBrace(lines: List<String>, startLine: Int): Int {
+        var depth = 0
+        var foundOpen = false
+        var inString = false
+        var inChar = false
+        var inLineComment = false
+        var inBlockComment = false
+        var inVerbatimString = false
+
+        for (i in startLine until lines.size) {
+            val line = lines[i]
+            inLineComment = false
+            var j = 0
+            while (j < line.length) {
+                val ch = line[j]
+                val next = if (j + 1 < line.length) line[j + 1] else '\u0000'
+
+                when {
+                    inBlockComment -> {
+                        if (ch == '*' && next == '/') {
+                            inBlockComment = false
+                            j++
+                        }
+                    }
+                    inLineComment -> { /* skip rest of line */ }
+                    inVerbatimString -> {
+                        if (ch == '"' && next == '"') {
+                            j++  // skip escaped quote
+                        } else if (ch == '"') {
+                            inVerbatimString = false
+                        }
+                    }
+                    inString -> {
+                        if (ch == '\\') j++  // skip escape
+                        else if (ch == '"') inString = false
+                    }
+                    inChar -> {
+                        if (ch == '\\') j++
+                        else if (ch == '\'') inChar = false
+                    }
+                    ch == '/' && next == '/' -> { inLineComment = true }
+                    ch == '/' && next == '*' -> { inBlockComment = true; j++ }
+                    ch == '@' && next == '"' -> { inVerbatimString = true; j++ }
+                    ch == '"' -> { inString = true }
+                    ch == '\'' -> { inChar = true }
+                    ch == '{' -> { depth++; foundOpen = true }
+                    ch == '}' -> {
+                        depth--
+                        if (foundOpen && depth == 0) return i
+                    }
+                }
+                j++
+            }
+        }
+
+        return lines.size - 1
+    }
+
+    /**
+     * Find the line containing the semicolon that ends a statement.
+     */
+    private fun findSemicolon(lines: List<String>, startLine: Int): Int {
+        for (i in startLine until minOf(startLine + 5, lines.size)) {
+            if (lines[i].contains(';')) return i
+        }
+        return startLine
+    }
+
+    /**
+     * Find the symbol at a given 1-based line and column.
+     */
+    fun findSymbolAt(parsedFile: ParsedFile, line: Int, column: Int): ParsedSymbol? {
+        return findSymbolAtRecursive(parsedFile.symbols, line, column)
+    }
+
+    private fun findSymbolAtRecursive(symbols: List<ParsedSymbol>, line: Int, column: Int): ParsedSymbol? {
+        // Find the most specific (deepest) symbol containing the position
+        for (symbol in symbols) {
+            if (line >= symbol.line && line <= symbol.endLine) {
+                // Check children first for more specific match
+                val childMatch = findSymbolAtRecursive(symbol.children, line, column)
+                if (childMatch != null) return childMatch
+                return symbol
+            }
+        }
+        return null
+    }
+
+    /**
+     * Find all symbols with a given name.
+     */
+    fun findSymbolsByName(parsedFile: ParsedFile, name: String): List<ParsedSymbol> {
+        val results = mutableListOf<ParsedSymbol>()
+        collectByName(parsedFile.symbols, name, results)
+        return results
+    }
+
+    private fun collectByName(symbols: List<ParsedSymbol>, name: String, results: MutableList<ParsedSymbol>) {
+        for (symbol in symbols) {
+            if (symbol.name == name) results.add(symbol)
+            collectByName(symbol.children, name, results)
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/csharp-support.xml
+++ b/core/src/main/resources/META-INF/csharp-support.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="info.jiayun.intellij-mcp">
+        <languageAdapter
+            implementation="info.jiayun.intellijmcp.csharp.CSharpLanguageAdapter"/>
+    </extensions>
+</idea-plugin>

--- a/core/src/main/resources/META-INF/plugin.xml
+++ b/core/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,7 @@
             <li>Java (requires Java plugin)</li>
             <li>Kotlin (requires Kotlin plugin)</li>
             <li>Rust (requires Rust plugin)</li>
+            <li>C# (requires Rider)</li>
             <li>Swift (macOS only, requires Xcode or Swift toolchain)</li>
         </ul>
     ]]></description>
@@ -52,6 +53,9 @@
 
     <!-- Optional Rust support - enabled when Rust plugin is installed -->
     <depends optional="true" config-file="rust-support.xml">com.jetbrains.rust</depends>
+
+    <!-- Optional C# support - enabled when running in Rider -->
+    <depends optional="true" config-file="csharp-support.xml">com.intellij.modules.rider</depends>
 
     <!-- Extension Point: Let language modules register adapters -->
     <extensionPoints>


### PR DESCRIPTION
## Summary

- Replace PSI-based C# adapter with a text-based parser (`CSharpTextParser`) that works reliably in Rider
- Rider uses ReSharper's .NET backend for C# — the IntelliJ frontend only exposes a minimal PSI facade, causing all PSI-based symbol resolution (`PsiNamedElement`, `PsiTreeUtil`) to return empty results
- The new parser extracts symbols from source text via regex patterns, similar to how the Swift adapter uses LSP as an alternative to PSI

### What's supported

- **Type declarations**: class, struct, enum, interface, record (with generics, base types, constraints)
- **Members**: methods, constructors, properties (block and expression-bodied), fields, events
- **Metadata**: modifiers, inline/multi-line attributes (`[SerializeField]`), XML doc comments (`///`)
- **Tools**: `get_file_symbols`, `get_symbol_info`, `find_symbol`, `find_references`, `get_type_hierarchy`

### Files changed

| File | Change |
|------|--------|
| `CSharpTextParser.kt` | New — regex-based C# source parser |
| `CSharpLanguageAdapter.kt` | Rewritten — uses text parser instead of PSI |
| `csharp-support.xml` | New — plugin extension registration |
| `plugin.xml` | Added optional Rider dependency |
| `build.gradle.kts` | Added C# to feature list, Rider run config |

## Test plan

- [x] Plugin compiles with `./gradlew :core:buildPlugin`
- [x] `get_file_symbols` returns class hierarchy with fields, methods, properties, events
- [x] `get_symbol_info` at a position returns correct symbol
- [x] `find_symbol` by name finds class definitions across project
- [x] Inline attributes (`[SerializeField] private Type name;`) correctly parsed
- [x] Expression-bodied properties (`Type Name => expr;`) detected as properties, not fields
- [x] Generic types (`List<T>`, `Action<T>`) handled in fields, properties, and base types

🤖 Generated with [Claude Code](https://claude.com/claude-code)